### PR TITLE
README + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 /public/.DS_Store
 /.npmrc
+/dist

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ This repo contains [ReactJS](https://react.dev) frontend code and makes use of c
 VITE_HOST="http://127.0.0.1:8080"
 VITE_WEBSOCKET="ws://127.0.0.1:8080"
 ```
-- Run `npm start`.
+- Run `npm run dev`.


### PR DESCRIPTION
replaced `npm start` with `npm run dev`

I added `/dist` to the `.gitignore` file.
It should not be in git, should it?

