### PR TITLE
Add shortcuts

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -27,6 +27,8 @@ const config = {
     skip: 's',
     rotate: 'r',
     rotateReverse: 't',
+    zoomIn: 'i',
+    zoomOut: 'o',
     nextTeam: 'n',
     currentTeam: 'c',
   }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -27,7 +27,8 @@ const config = {
     skip: 's',
     rotate: 'r',
     rotateReverse: 't',
-    
+    nextTeam: 'n',
+    currentTeam: 'c',
   }
 }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -20,7 +20,15 @@ const config = {
   color: "orange-600",
 
   // misc attributes
-  gamePageMaxWidth: "max-w-6xl"
+  gamePageMaxWidth: "max-w-6xl",
+
+  // keyboard shortcuts
+  shortcut: {
+    skip: 's',
+    rotate: 'r',
+    rotateReverse: 't',
+    
+  }
 }
 
 export default function App() {
@@ -60,7 +68,8 @@ export default function App() {
                 error={ error } setError={ setError }>
                   <Game ref={ ref } ws={ ws }
                     game={ game } network={ network } 
-                    chat={ chat } connected={ connected } error={ error } />
+                    chat={ chat } connected={ connected } error={ error } 
+                    shortcut={ config.shortcut } />
               </GamePage>
             }
           />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -31,6 +31,7 @@ const config = {
     zoomOut: 'o',
     nextTeam: 'n',
     currentTeam: 'c',
+    undo: 'u',
   }
 }
 

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -215,8 +215,8 @@ export const Game = forwardRef((props, ref) => {
                                 if (zoom < 1) setZoom(zoom + 0.1)
                             }} className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center mb-2 select-none">+</div>
                             <div onClick={() => {
-                            if (zoom >= .4) setZoom(zoom - 0.1)
-                        }} className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
+                                if (zoom >= .4) setZoom(zoom - 0.1)
+                            }} className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
                         </div>
                     </div>
                     <div className="sticky w-full top-[93%] h-0 flex justify-between z-[999]">

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -36,9 +36,10 @@ export const Game = forwardRef((props, ref) => {
         }));
     }, [ws])
 
-    const sendRotateTileAction = useCallback((team) => {
+    const sendRotateTileAction = useCallback((team, rotateRight=true) => {
         if (!ws.current) return;
-        ws.current.send(JSON.stringify({"ActionType": "RotateTileRight", "Team": team}));
+        let actionType = rotateRight ? "RotateTileRight" : "RotateTileLeft"
+        ws.current.send(JSON.stringify({"ActionType": actionType, "Team": team}));
     }, [ws])
 
     const sendPlaceTokenAction = useCallback((team, x, y, type, side) => {
@@ -165,9 +166,20 @@ export const Game = forwardRef((props, ref) => {
     // handle what happens on key press
     const handleKeyPress = useCallback((event) => {
         if (event.key === 's') {
+            // skip
             sendPassAction(team)
         } else if (event.key === 'r') {
-            game.Winners.length === 0 ? sendRotateTileAction(team) : null
+            // rotate
+            if (game.Winners.length !== 0) {
+                return
+            }
+            sendRotateTileAction(team)
+        } else if (event.key === 't') {
+            // rotate other direction (maybe shirt+r better?)
+            if (game.Winners.length !== 0) {
+                return
+            }
+            sendRotateTileAction(team,false)
         }
     }, [team, game]);
 

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -162,6 +162,25 @@ export const Game = forwardRef((props, ref) => {
         setScrollY(sY)
     }
 
+    // handle what happens on key press
+    const handleKeyPress = useCallback((event) => {
+        if (event.key === 's') {
+            sendPassAction(team)
+        } else if (event.key === 'r') {
+            game.Winners.length === 0 ? sendRotateTileAction(team) : null
+        }
+    }, [team, game]);
+
+    useEffect(() => {
+        // attach the event listener
+        document.addEventListener('keydown', handleKeyPress);
+
+        // remove the event listener
+        return () => {
+            document.removeEventListener('keydown', handleKeyPress);
+        };
+    }, [handleKeyPress]);
+
     return (
         <DndContext autoScroll={ false } onDragEnd={ handleDragEnd } sensors={ sensors }>
             <div className="w-full flex flex-col justify-center items-center grow">

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -79,6 +79,7 @@ export const Game = forwardRef((props, ref) => {
 
     // board rendering
     const [zoom, setZoom] = useState(1);
+    // console.log(zoom, setZoom)
     const [minX, setMinX] = useState(0);
     const [maxX, setMaxX] = useState(0);
     const [minY, setMinY] = useState(0);
@@ -163,6 +164,81 @@ export const Game = forwardRef((props, ref) => {
         setScrollY(sY)
     }
 
+    /// Try 2:
+
+    // const zoomIn = useCallback(() => {
+    //     console.log('in zoom', zoom)
+
+    //     if (zoom < 1) {
+    //         setZoom(zoom + 0.1)
+    //         console.log("zoomed in")
+    //     }
+    // }, [zoom,setZoom]);
+    // const zoomOut = useCallback(() => {
+    //     console.log('out zoom', zoom)
+    //     if (zoom >= .4) {
+    //         setZoom(zoom - 0.1)
+    //         console.log("zoomed out")
+    //     }
+    // }, [zoom,setZoom]);
+
+    /// Try 1:
+    // const zoomIn = () => {
+    //     console.log('in zoom', zoom)
+
+    //     if (zoom < 1) {
+    //         setZoom(zoom + 0.1)
+    //         console.log("zoomed in")
+    //     }
+    // }
+    // const zoomOut = () => {
+    //     console.log('out zoom', zoom)
+    //     if (zoom >= .4) {
+    //         setZoom(zoom - 0.1)
+    //         console.log("zoomed out")
+    //     }
+    // }
+
+    /// Try 3:
+    const zoomFunctions = {
+        // zoomIn: () => {
+        //     console.log('in zoom', zoom)
+
+        //     if (zoom < 1) {
+        //         setZoom(zoom + 0.1)
+        //         console.log("zoomed in")
+        //     }
+        // },
+        // zoomOut: () => {
+        //     console.log('out zoom', zoom)
+        //     if (zoom >= .4) {
+        //         setZoom(zoom - 0.1)
+        //         console.log("zoomed out")
+        //     }
+        // }
+    }
+    useEffect(() => {
+        console.log('zoom value', zoom);
+        zoomFunctions.zoomIn = () => {
+            console.log('in zoom', zoom)
+
+            if (zoom < 1) {
+                setZoom(zoom + 0.1)
+                console.log("zoomed in")
+            }
+        }
+        zoomFunctions.zoomOut= () => {
+            console.log('out zoom', zoom)
+            if (zoom >= .4) {
+                setZoom(zoom - 0.1)
+                console.log("zoomed out")
+            }
+        }
+    });
+    // }, []);
+    // }, [zoom, setZoom, zoomFunctions]);
+
+
     // handle what happens on key press
     const handleKeyPress = useCallback((event) => {
         if (event.key === shortcut.skip) {
@@ -180,6 +256,12 @@ export const Game = forwardRef((props, ref) => {
                 return
             }
             sendRotateTileAction(team,false)
+        } else if (event.key === shortcut.zoomIn) {
+            console.log("zoom in from: ", zoom)
+            zoomFunctions.zoomIn(zoom)
+        } else if (event.key === shortcut.zoomOut) {
+            console.log("zoom out from: ", zoom)
+            zoomFunctions.zoomOut(zoom)
         }
     }, [team, game]);
 
@@ -211,12 +293,8 @@ export const Game = forwardRef((props, ref) => {
                             </div>
                         </div>
                         <div className="m-2">
-                            <div onClick={ () => {
-                                if (zoom < 1) setZoom(zoom + 0.1)
-                            }} className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center mb-2 select-none">+</div>
-                            <div onClick={() => {
-                                if (zoom >= .4) setZoom(zoom - 0.1)
-                            }} className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
+                            <div onClick={ zoomFunctions.zoomIn } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center mb-2 select-none">+</div>
+                            <div onClick={ zoomFunctions.zoomOut } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
                         </div>
                     </div>
                     <div className="sticky w-full top-[93%] h-0 flex justify-between z-[999]">

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -12,7 +12,7 @@ import { COLORMAP } from "./models/color";
 
 export const Game = forwardRef((props, ref) => {
     // eslint-disable-next-line no-unused-vars
-    const { ws, game, network, chat, connected, error } = props;
+    const { ws, game, network, chat, connected, error, shortcut} = props;
 
     // websocket messages
     const sendPlaceTileAction = useCallback((team, x, y, top, right, bottom, left, center, connectedCitySides, banner) => {
@@ -165,16 +165,16 @@ export const Game = forwardRef((props, ref) => {
 
     // handle what happens on key press
     const handleKeyPress = useCallback((event) => {
-        if (event.key === 's') {
+        if (event.key === shortcut.skip) {
             // skip
             sendPassAction(team)
-        } else if (event.key === 'r') {
+        } else if (event.key === shortcut.rotate) {
             // rotate
             if (game.Winners.length !== 0) {
                 return
             }
             sendRotateTileAction(team)
-        } else if (event.key === 't') {
+        } else if (event.key === shortcut.rotateReverse) {
             // rotate other direction (maybe shirt+r better?)
             if (game.Winners.length !== 0) {
                 return

--- a/src/components/game/Game.jsx
+++ b/src/components/game/Game.jsx
@@ -164,80 +164,12 @@ export const Game = forwardRef((props, ref) => {
         setScrollY(sY)
     }
 
-    /// Try 2:
-
-    // const zoomIn = useCallback(() => {
-    //     console.log('in zoom', zoom)
-
-    //     if (zoom < 1) {
-    //         setZoom(zoom + 0.1)
-    //         console.log("zoomed in")
-    //     }
-    // }, [zoom,setZoom]);
-    // const zoomOut = useCallback(() => {
-    //     console.log('out zoom', zoom)
-    //     if (zoom >= .4) {
-    //         setZoom(zoom - 0.1)
-    //         console.log("zoomed out")
-    //     }
-    // }, [zoom,setZoom]);
-
-    /// Try 1:
-    // const zoomIn = () => {
-    //     console.log('in zoom', zoom)
-
-    //     if (zoom < 1) {
-    //         setZoom(zoom + 0.1)
-    //         console.log("zoomed in")
-    //     }
-    // }
-    // const zoomOut = () => {
-    //     console.log('out zoom', zoom)
-    //     if (zoom >= .4) {
-    //         setZoom(zoom - 0.1)
-    //         console.log("zoomed out")
-    //     }
-    // }
-
-    /// Try 3:
-    const zoomFunctions = {
-        // zoomIn: () => {
-        //     console.log('in zoom', zoom)
-
-        //     if (zoom < 1) {
-        //         setZoom(zoom + 0.1)
-        //         console.log("zoomed in")
-        //     }
-        // },
-        // zoomOut: () => {
-        //     console.log('out zoom', zoom)
-        //     if (zoom >= .4) {
-        //         setZoom(zoom - 0.1)
-        //         console.log("zoomed out")
-        //     }
-        // }
+    const zoomIn = () => {
+        if (zoom < 1) setZoom(zoom + 0.1)
     }
-    useEffect(() => {
-        console.log('zoom value', zoom);
-        zoomFunctions.zoomIn = () => {
-            console.log('in zoom', zoom)
-
-            if (zoom < 1) {
-                setZoom(zoom + 0.1)
-                console.log("zoomed in")
-            }
-        }
-        zoomFunctions.zoomOut= () => {
-            console.log('out zoom', zoom)
-            if (zoom >= .4) {
-                setZoom(zoom - 0.1)
-                console.log("zoomed out")
-            }
-        }
-    });
-    // }, []);
-    // }, [zoom, setZoom, zoomFunctions]);
-
+    const zoomOut = () => {
+        if (zoom >= .4) setZoom(zoom - 0.1)
+    }
 
     // handle what happens on key press
     const handleKeyPress = useCallback((event) => {
@@ -257,13 +189,11 @@ export const Game = forwardRef((props, ref) => {
             }
             sendRotateTileAction(team,false)
         } else if (event.key === shortcut.zoomIn) {
-            console.log("zoom in from: ", zoom)
-            zoomFunctions.zoomIn(zoom)
+            zoomIn()
         } else if (event.key === shortcut.zoomOut) {
-            console.log("zoom out from: ", zoom)
-            zoomFunctions.zoomOut(zoom)
+            zoomOut()
         }
-    }, [team, game]);
+    }, [team, game, zoom]);
 
     useEffect(() => {
         // attach the event listener
@@ -293,8 +223,8 @@ export const Game = forwardRef((props, ref) => {
                             </div>
                         </div>
                         <div className="m-2">
-                            <div onClick={ zoomFunctions.zoomIn } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center mb-2 select-none">+</div>
-                            <div onClick={ zoomFunctions.zoomOut } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
+                            <div onClick={ zoomIn } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center mb-2 select-none">+</div>
+                            <div onClick={ zoomOut } className="rounded-full w-10 h-10 bg-zinc-600 cursor-pointer font-bold text-3xl flex items-center justify-center select-none">-</div>
                         </div>
                     </div>
                     <div className="sticky w-full top-[93%] h-0 flex justify-between z-[999]">


### PR DESCRIPTION
Add shortcuts for:
- r: rotating the tile to place clockwise 
- t: rotating the tile to place counterclockwise
- s: skip placing a token
- i: zoom in
- o: zoom out

The shortcuts are defined in [App.jsx](https://github.com/quibbble/carcassonne/blob/main/src/components/App.jsx)
This config is also used by the boardgame shortcuts as seen in this [pullrequest](https://github.com/quibbble/boardgame/pull/8)